### PR TITLE
Pratt Parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +206,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "ysetl"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "pest",
  "pest_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lazy_static = "1.4.0"
 pest = "2.6.0"
 pest_derive = "2.6.0"

--- a/rubric.ysetl
+++ b/rubric.ysetl
@@ -20,7 +20,7 @@ a @ b;
 input %* literals;
 input %(bar + jar) literals;
 input %foo literals;
-//input .foo other;
+input .foo other;
 
 aaaa %foo bbbb %bar cccc;
 
@@ -28,3 +28,5 @@ aaaa %foo bbbb %bar cccc;
 9 * 8 * 6;
 9 + 2 - 7;
 1 * 2 + 3 * 4;
+
+-not !#@lotta_unaries;

--- a/rubric.ysetl
+++ b/rubric.ysetl
@@ -1,10 +1,11 @@
 program :rubric;
 
 null;
-foo_bar;
-(newat);
+newat;
 true;
 false;
+foo_bar;
+funny + boi;
 "hello, world";
 100;
 0;
@@ -17,7 +18,11 @@ foo ?? bar ?? baz;
 a @ b;
 
 input %* literals;
-input %.foo literals;
+input %(bar + jar) literals;
+input %foo literals;
+//input .foo other;
+
+aaaa %foo bbbb %bar cccc;
 
 2**3**4;
 9 * 8 * 6;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ use parser::parser::parse_program;
 
 pub mod parser;
 
+static INPUT_PATH: &'static str = "rubric.ysetl";
+
 fn main() {
-    let input = fs::read_to_string("rubric.ysetl").expect("Error opening file");
+    let input = fs::read_to_string(INPUT_PATH).expect("Error opening file");
     parse_program(&input).unwrap();
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -16,6 +16,15 @@ pub enum BinOp {
 }
 
 #[derive(Debug)]
+pub enum PreOp {
+    Negate,
+    Id,
+    DynVar, // Dynamic variable
+    Size,
+    Not,
+}
+
+#[derive(Debug)]
 pub enum ExprST<'a> {
     Null,
     Newat,
@@ -29,4 +38,7 @@ pub enum ExprST<'a> {
     Infix{op: BinOp, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
     ReduceWithOp{op: BinOp, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
     ReduceWithExpr{apply: Box<ExprST<'a>>, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
+    InfixInject{apply: Box<ExprST<'a>>, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
+    Prefix{op: PreOp, right: Box<ExprST<'a>>},
+    Call{left: Box<ExprST<'a>>}, // Needs info about selectors
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,7 +1,7 @@
 #[derive(Debug)]
-pub enum Op {
+pub enum BinOp {
     NullCoal,
-    At,
+    TupleStart,
     Exp,
     Mult,
     Inter,
@@ -26,7 +26,7 @@ pub enum ExprST<'a> {
     Ident(&'a str),
     Integer(i64),
     Float(f64),
-    Infix{op: Op, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
-    ReduceWithOp{op: Op, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
+    Infix{op: BinOp, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
+    ReduceWithOp{op: BinOp, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
     ReduceWithExpr{apply: Box<ExprST<'a>>, left: Box<ExprST<'a>>, right: Box<ExprST<'a>>},
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,14 +1,42 @@
 use pest::Parser;
 use pest_derive::Parser;
 use pest::error::Error;
-use pest::iterators::{Pair, Pairs};
+use pest::iterators::{Pair};
+use pest::pratt_parser::PrattParser;
+use lazy_static;
 
 use super::ast::ExprST;
-use super::ast::Op;
+use super::ast::BinOp;
 
 #[derive(Parser)]
 #[grammar="parser/ysetl.pest"]
 struct YsetlParser;
+
+type ExprResult<'a> = Result<ExprST<'a>, String>;
+
+lazy_static::lazy_static! {
+    static ref PRATT_PARSER: PrattParser<Rule> = {
+        use pest::pratt_parser::{Op, Assoc};
+        
+        PrattParser::new()
+            .op(Op::infix(Rule::plus, Assoc::Left) |
+                Op::infix(Rule::dash, Assoc::Left) |
+                Op::infix(Rule::with, Assoc::Left) |
+                Op::infix(Rule::less, Assoc::Left) |
+                Op::infix(Rule::union_, Assoc::Left)
+            )
+            .op(Op::infix(Rule::star, Assoc::Left) |
+                Op::infix(Rule::slash, Assoc::Left) |
+                Op::infix(Rule::mod_, Assoc::Left) |
+                Op::infix(Rule::div, Assoc::Left) |
+                Op::infix(Rule::inter, Assoc::Left)
+            )
+            .op(Op::infix(Rule::dbl_star, Assoc::Right))
+            .op(Op::infix(Rule::reduce_op, Assoc::Right))
+            .op(Op::infix(Rule::dbl_qst, Assoc::Right))
+            .op(Op::infix(Rule::at, Assoc::Right))
+    };
+}
 
 pub fn parse_program(input: &str) -> Result<(), Error<Rule>> {
     let program = YsetlParser::parse(Rule::program_input, input)?.next().unwrap();
@@ -23,6 +51,7 @@ pub fn parse_program(input: &str) -> Result<(), Error<Rule>> {
             let program_name = atom_value(name_node);
 
             println!("Executing program '{}'", program_name);
+            println!("Rest of program\n\n{:?}\n\n", inner);
             for pair in inner {
                 println!("{} -> {:?}", pair.as_str(), parse_expr(pair));
             }
@@ -87,112 +116,105 @@ fn construct_number(
 }
 
 #[allow(dead_code)]
-fn inspect(input: Pair<Rule>) -> Result<ExprST, String> {
+fn inspect(input: Pair<Rule>) -> ExprResult {
     println!("{:?}", input);
     Ok(ExprST::Null)
 }
 
-fn to_op(input: &Pair<Rule>) -> Option<Op> {
-    let rule = input.as_rule();
+fn to_binop(rule: Rule) -> BinOp {
     match rule {
-        Rule::at => Some(Op::At),
-        Rule::dbl_qst => Some(Op::NullCoal),
-        Rule::dbl_star => Some(Op::Exp),
-        Rule::star => Some(Op::Mult),
-        Rule::inter => Some(Op::Inter),
-        Rule::slash => Some(Op::Div),
-        Rule::div => Some(Op::IntDiv),
-        Rule::mod_ => Some(Op::IntDiv),
-        Rule::plus => Some(Op::Add),
-        Rule::dash => Some(Op::Subtract),
-        Rule::with => Some(Op::With),
-        Rule::less => Some(Op::Less),
-        Rule::union_ => Some(Op::Union),
-        _ => None,
+        Rule::plus => BinOp::Add,
+        Rule::dash => BinOp::Subtract,
+        Rule::with => BinOp::With,
+        Rule::less => BinOp::Less,
+        Rule::union_ => BinOp::Union,
+        Rule::star => BinOp::Mult,
+        Rule::slash => BinOp::Div,
+        Rule::mod_ => BinOp::Mod,
+        Rule::div => BinOp::IntDiv,
+        Rule::inter => BinOp::Inter,
+        Rule::dbl_star => BinOp::Exp,
+        Rule::dbl_qst => BinOp::NullCoal,
+        Rule::at => BinOp::TupleStart, 
+        _ => unreachable!("Expected pure binary operator, received {:?}", rule),
     }
 }
 
-fn parse_nonassoc_infix(mut parts: Pairs<Rule>) -> ExprST {
-    let first = parse_expr(parts.next().unwrap()).unwrap();
-    match parts.next() {
-        Some(op_rule) => ExprST::Infix {
-            op: to_op(&op_rule).unwrap(),
-            left: Box::new(first),
-            right: Box::new(parse_expr(parts.next().unwrap()).unwrap()),
-            // Maybe check if there are more parts?
-        },
-        None => first,
+fn to_infix<'a>(lhs: ExprResult<'a>, rhs: ExprResult<'a>, op: BinOp) -> ExprResult<'a> {
+    Ok(ExprST::Infix {
+        op: op,
+        left: Box::new(lhs?),
+        right: Box::new(rhs?),
+    })
+}
+
+fn to_reduce_expr<'a>(lhs: ExprResult<'a>, rhs: ExprResult<'a>, op: Pair<'a, Rule>) -> ExprResult<'a> {
+    let inner_op = op.into_inner().next().unwrap();
+    let left = Box::new(lhs?);
+    let right = Box::new(rhs?);
+    match inner_op.as_rule() {
+        Rule::nested_expression | Rule::ident => Ok(ExprST::ReduceWithExpr {
+            apply: Box::new(map_primary_to_expr(inner_op).unwrap()),
+            left,
+            right,
+        }),
+        bin_op => Ok(ExprST::ReduceWithOp {
+            op: to_binop(bin_op),
+            left,
+            right,
+        })
     }
 }
 
-fn parse_right_assoc_infix(mut parts: Pairs<Rule>) -> ExprST {
-    let first = parse_expr(parts.next().unwrap()).unwrap();
-    match parts.next() {
-        Some(op_rule) => ExprST::Infix {
-            op: to_op(&op_rule).unwrap(),
-            left: Box::new(first),
-            right: Box::new(parse_right_assoc_infix(parts)),
-        },
-        None => first,
-    }
-}
-
-fn parse_left_assoc_infix(mut parts: Pairs<Rule>) -> ExprST {
-    let last = parse_expr(parts.next_back().unwrap()).unwrap();
-    match parts.next_back() {
-        Some(op_rule) => ExprST::Infix {
-            op: to_op(&op_rule).unwrap(),
-            left: Box::new(parse_left_assoc_infix(parts)),
-            right: Box::new(last),
-        },
-        None => last
-    }
-}
-
-// More specific than the general non-assoc parse handler
-fn parse_reduce_infix(mut parts: Pairs<Rule>) -> ExprST {
-    let first = parse_expr(parts.next().unwrap()).unwrap();
-    match parts.next() {
-        Some(_) => {
-            let operation = parts.next().unwrap();
-            match to_op(&operation) {
-                Some(op) => ExprST::ReduceWithOp {
-                    op: op,
-                    left: Box::new(first),
-                    right: Box::new(parse_expr(parts.next().unwrap()).unwrap()),
-                },  
-                // If `to_op` doesn't catch the operation pair, than it's an infix binop, and
-                // the operation is actually just a dot which can be ignored in favor of the
-                // following token
-                None => ExprST::ReduceWithExpr {
-                    apply: Box::new(parse_expr(parts.next().unwrap()).unwrap()),
-                    left: Box::new(first),
-                    right: Box::new(parse_expr(parts.next().unwrap()).unwrap()),
-                },
-            }
-        },
-        None => first,
-    }
-}
-
-fn parse_expr(input: Pair<Rule>) -> Result<ExprST, String> {
-    match input.as_rule() {
+fn map_primary_to_expr(primary: Pair<Rule>) -> ExprResult {
+    match primary.as_rule() {
         Rule::null => Ok(ExprST::Null),
         Rule::newat => Ok(ExprST::Newat),
         Rule::true_ => Ok(ExprST::True),
         Rule::false_ => Ok(ExprST::False),
-        Rule::atom => Ok(ExprST::Atom(atom_value(input))),
-        Rule::string => Ok(ExprST::String(string_value(input))),
-        Rule::ident => Ok(ExprST::Ident(input.as_str())),
-        Rule::number => Ok(number_value(input)),
-        Rule::null_coal_expr => Ok(parse_right_assoc_infix(input.into_inner())),
-        Rule::tuple_start_expr => Ok(parse_nonassoc_infix(input.into_inner())),
-        Rule::reduce_expr => Ok(parse_reduce_infix(input.into_inner())),
-        Rule::exponent_expr => Ok(parse_right_assoc_infix(input.into_inner())),
-        Rule::mult_expr => Ok(parse_left_assoc_infix(input.into_inner())),
-        Rule::add_expr => Ok(parse_left_assoc_infix(input.into_inner())),
-        _ => {
-           Err(format!("Unexpected expression type: {:?}", input.as_rule()))
-        }
+        Rule::atom => Ok(ExprST::Atom(atom_value(primary))),
+        Rule::string => Ok(ExprST::String(string_value(primary))),
+        Rule::ident => Ok(ExprST::Ident(primary.as_str())),
+        Rule::number => Ok(number_value(primary)),
+        Rule::nested_expression => parse_expr(primary.into_inner().next().unwrap()),
+        rule => unreachable!("parse_expr expected primary, received {:?}", rule),
+    }
+}
+
+fn parse_bin_expr(input: Pair<Rule>) -> ExprResult {
+    PRATT_PARSER
+        .map_primary(map_primary_to_expr)
+        .map_infix(|lhs, op, rhs| {
+            let op_rule = op.as_rule();
+            match op_rule {
+                // Normal Rules
+                  Rule::plus
+                | Rule::dash
+                | Rule::with
+                | Rule::less
+                | Rule::union_
+                | Rule::star
+                | Rule::slash
+                | Rule::mod_
+                | Rule::div
+                | Rule::inter
+                | Rule::dbl_star
+                | Rule::dbl_qst
+                | Rule::at => to_infix(lhs, rhs, to_binop(op_rule)),
+
+                // Special operator infix
+                // Rule::reduce_op => inspect(op),
+                Rule::reduce_op => to_reduce_expr(lhs, rhs, op),
+                rule => unreachable!("parse_expr expected infix expression, received {:?}", rule),
+            }
+        })
+        .parse(input.into_inner())
+}
+
+fn parse_expr(input: Pair<Rule>) -> ExprResult {
+    match input.as_rule() {
+        // There will be non-binop expressions that go here
+        Rule::bin_expr => parse_bin_expr(input),
+        _ => unreachable!(),
     }
 }

--- a/src/parser/ysetl.pest
+++ b/src/parser/ysetl.pest
@@ -26,7 +26,7 @@ union_ = { "union" }
 in = { "in" }
 notin = { "notin" }
 subset = { "subset" }
-not = { "not" }
+not = @{ "not" ~ WHITESPACE }
 and = { "and" }
 or = { "or" }
 impl = { "impl" }
@@ -56,21 +56,27 @@ l_brack = _{ "[" }
 r_brack = _{ "]" }
 
 // Operator symbols
+// I need to use separate rules for symbols that can be either prefix or infix,
+// otherwise the pratt parser has a fit.
 
 at = { "@" }
+at_pre = { "@" }
+plus = { "+" }
+plus_pre = { "+" }
+dash = { "-" }
+dash_pre = { "-" }
 eq = { "=" }
 pipe = { "|" }
-dot = { "." }
+dot = _{ "." }
 hash = { "#" }
 qst = { "?" }
 star = { "*" }
 slash = { "/" }
-plus = { "+" }
-dash = { "-" }
 lodash = { "_" }
 lt = { "<" }
 gt = { ">" }
 tilde = { "~" }
+bang = { "!" }
 
 bollocks = { ":=" }
 dbl_dot = { ".." }
@@ -90,7 +96,9 @@ arrow = { "=>" }
 
 nested_expression = { l_paren ~ expr ~ r_paren }
 
-unary_op          = _{ hash | dash | plus | at }
+infix_op          = _{ ident | nested_expression }
+
+prefix_op         = _{ dash_pre | plus_pre | at_pre | hash | bang | not }
 
 tuple_start_op    = _{ at }
 
@@ -104,13 +112,11 @@ mult_op           = _{ star | slash | mod_ | div | inter }
 
 add_op            = _{ plus | dash | with | less | union_ }
 
-infix_op          = _{ ident | nested_expression }
+infix_inject      = { dot ~ infix_op }
 
 set_op            = { in | notin | subset }
 
 compare_op        = { lt | lt_eq | gt | gt_eq | eq | bang_eq }
-
-not_op            = { not }
 
 and_op            = { and | dbl_amp }
 
@@ -131,10 +137,10 @@ bin_op = _{
    | mult_op
    | add_op
    | reduce_op
+   | infix_inject
    // | and_op
    // | or_op
    // | impl_op
-   | infix_op
 }
 
 // Literals
@@ -144,13 +150,11 @@ atom = ${
    colon ~ atom_keep
 }
 
-number_dash = { dash? }
-number_base = { ASCII_DIGIT+ }
-number_decimal = { (dot ~ ASCII_DIGIT+)? }
-number_exp = { ((^"e" | ^"f") ~ (plus | dash)? ~ ASCII_DIGIT+)? }
+number_base = @{ ASCII_DIGIT+ }
+number_decimal = @{ (dot ~ ASCII_DIGIT+)? }
+number_exp = @{ ((^"e" | ^"f") ~ (plus | dash)? ~ ASCII_DIGIT+)? }
 number = ${
-   number_dash
-   ~ number_base
+   number_base
    ~ number_decimal
    ~ number_exp
 }
@@ -178,14 +182,8 @@ primary = _{
    | nested_expression
 }
 
-// postfix_expr = ${
-//    primary ~ ("()")*
-// }
+empty_call = { "()" }
 
-// prefix_expr = ${ unary_op ~ unary }
-
-// unary = _{ prefix_expr | postfix_expr }
-
-bin_expr = { primary ~ (bin_op ~ primary)* }
+bin_expr = { prefix_op* ~ primary ~ empty_call* ~ (bin_op ~ prefix_op* ~ primary ~ empty_call*)* }
 
 expr = _{ bin_expr }

--- a/src/parser/ysetl.pest
+++ b/src/parser/ysetl.pest
@@ -37,11 +37,16 @@ choose = { "choose" }
 where = { "where" }
 
 // Non-operator Symbols
+// Some of these are technically operators, but it's better
+// if they don't produce tokens because they're part of a
+// more complex operator, like `percent`
 
 semicolon = _{ ";" }
 colon = _{ ":" }
 comma = _{ "," }
 b_slash = _{ "\\" }
+quote = _{ "\"" }
+percent = _{ "%" }
 
 l_brace = _{ "{" }
 r_brace = _{ "}" }
@@ -63,10 +68,8 @@ slash = { "/" }
 plus = { "+" }
 dash = { "-" }
 lodash = { "_" }
-quote = { "\"" }
 lt = { "<" }
 gt = { ">" }
-percent = { "%" }
 tilde = { "~" }
 
 bollocks = { ":=" }
@@ -85,49 +88,52 @@ arrow = { "=>" }
 
 // Operator groups
 
-unary_op        = _{ hash | dash | plus | at }
+nested_expression = { l_paren ~ expr ~ r_paren }
 
-tuple_start_op  = _{ at }
+unary_op          = _{ hash | dash | plus | at }
 
-expr_or_op      = _{ qst }
+tuple_start_op    = _{ at }
 
-reduce_op       = _{ percent }
+null_coal_op      = _{ dbl_qst }
 
-exp_op          = _{ dbl_star }
+reduce_op         = { percent ~ (infix_op | bin_op) }
 
-mult_op         = _{ star | slash | mod_ | div | inter }
+exp_op            = _{ dbl_star }
 
-add_op          = _{ plus | dash | with | less | union_ }
+mult_op           = _{ star | slash | mod_ | div | inter }
 
-infix_id_func   = _{ ident }
-infix_expr_func = _{ l_paren ~ expr ~ r_paren }
-infix_op        = _{ dot ~ (infix_id_func | infix_expr_func) }
+add_op            = _{ plus | dash | with | less | union_ }
 
-set_op          = _{ in | notin | subset }
+infix_op          = _{ ident | nested_expression }
 
-compare_op      = _{ lt | lt_eq | gt | gt_eq | eq | bang_eq }
+set_op            = { in | notin | subset }
 
-not_op          = _{ not }
+compare_op        = { lt | lt_eq | gt | gt_eq | eq | bang_eq }
 
-and_op          = _{ and | dbl_amp }
+not_op            = { not }
 
-or_op           = _{ or | dbl_pipe }
+and_op            = { and | dbl_amp }
 
-impl_op         = _{ impl }
+or_op             = { or | dbl_pipe }
 
-iff_op          = _{ iff }
+impl_op           = { impl }
 
-select_op       = _{ exists | forall | choose }
+iff_op            = { iff }
 
-where_op        = _{ where }
+select_op         = { exists | forall | choose }
+
+where_op          = { where }
 
 bin_op = _{
-     exp_op
+   | tuple_start_op
+   | null_coal_op
+   | exp_op
    | mult_op
    | add_op
-   | and_op
-   | or_op
-   | impl_op
+   | reduce_op
+   // | and_op
+   // | or_op
+   // | impl_op
    | infix_op
 }
 
@@ -161,7 +167,7 @@ ident = @{ (ASCII_ALPHA | lodash) ~ (ASCII_ALPHANUMERIC | lodash)* }
 // Expressions
 
 primary = _{
-     null // More ubiquitous than "OM"
+   | null // More ubiquitous than "OM"
    | newat
    | true_
    | false_
@@ -169,28 +175,17 @@ primary = _{
    | number
    | string
    | ident // Must follow primary keywords and function literal
-   | nested_expression // The absolute highest priority
+   | nested_expression
 }
 
-// This precencende climbing method is what I'm used to with PEG parsers
-// However, it appears to use a lot of memory due to a primary being wrapped
-// with layers and layers of other expressions. Maybe I need to use a Pratt
-// parser instead.
+// postfix_expr = ${
+//    primary ~ ("()")*
+// }
 
-nested_expression = _{ l_paren ~ expr ~ r_paren }
+// prefix_expr = ${ unary_op ~ unary }
 
-null_coal_expr = { primary ~ (dbl_qst ~ primary)* }
+// unary = _{ prefix_expr | postfix_expr }
 
-tuple_start_expr = { null_coal_expr ~ (at ~ null_coal_expr)? }
+bin_expr = { primary ~ (bin_op ~ primary)* }
 
-reduce_expr = { tuple_start_expr ~ (percent ~ bin_op ~ tuple_start_expr)? }
-
-exponent_expr = { reduce_expr ~ (exp_op ~ reduce_expr)* }
-
-mult_expr = { exponent_expr ~ (mult_op ~ exponent_expr)* }
-
-add_expr = { mult_expr ~ (add_op ~ mult_expr)* }
-
-expr = _{ add_expr }
-
-// expr_list = { expr ~ (comma ~ expr)* }
+expr = _{ bin_expr }


### PR DESCRIPTION
Implemented the _binary expression / unary expression / primary_ branches using Pest's Pratt parser. The way I'm used to implementing operator precedence via PEG parsers relies on predicates to immediately unwrap expressions as they're being parsed. Since Pest doesn't have predicates in the grammar, the same approach would mean that the immediate parse would return primary values that are deeply nested within layers and layers of expression wrappers. This is super wasteful. In order to parse my grammar the Pest way, I flattened my expression tree and passed it through a Pratt parser to build the AST.